### PR TITLE
修复了一些小问题

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -183,7 +183,7 @@ onBeforeUnmount(() => {
     .i-icon {
       transform: translateY(2px);
     }
-    @media (min-width: 720px) {
+    @media (min-width: 721px) {
       display: none;
     }
   }

--- a/src/App.vue
+++ b/src/App.vue
@@ -17,7 +17,12 @@
         </section>
       </div>
       <!-- 移动端菜单按钮 -->
-      <Icon class="menu" size="24" @click="store.mobileOpenState = !store.mobileOpenState">
+      <Icon
+        class="menu"
+        size="24"
+        v-show="!store.backgroundShow"
+        @click="store.mobileOpenState = !store.mobileOpenState"
+      >
         <component :is="store.mobileOpenState ? CloseSmall : HamburgerButton" />
       </Icon>
       <!-- 页脚 -->

--- a/src/components/Background.vue
+++ b/src/components/Background.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="cover">
+  <div :class="store.backgroundShow ? 'cover show' : 'cover'">
     <img
       v-show="store.imgLoadStatus"
       class="bg"
@@ -98,6 +98,10 @@ onBeforeUnmount(() => {
   height: 100%;
   transition: 0.25s;
   z-index: -1;
+
+  &.show {
+    z-index: 1;
+  }
 
   .bg {
     position: absolute;

--- a/src/components/Music.vue
+++ b/src/components/Music.vue
@@ -42,7 +42,7 @@
     </div>
   </div>
   <!-- 音乐列表弹窗 -->
-  <Transition name="fade">
+  <Transition name="fade" mode="out-in">
     <div class="music-list" v-show="musicListShow" @click="musicListShow = false">
       <Transition name="zoom">
         <div class="list" v-show="musicListShow" @click.stop>
@@ -281,12 +281,6 @@ watch(
 }
 
 // 弹窗动画
-.fade-enter-active {
-  animation: fade 0.3s ease-in-out;
-}
-.fade-leave-active {
-  animation: fade 0.3s ease-in-out reverse;
-}
 .zoom-enter-active {
   animation: zoom 0.4s ease-in-out;
 }


### PR DESCRIPTION
1. 在 **Safari** 浏览器因为动画重复导致在关闭 **音乐列表** 时，屏幕闪烁
2. 在 `720px` 以下宽度的时候，打开 **壁纸展示** 状态，移动端的菜单按钮 **不会隐藏**
3. 在 `720px` 宽度的时候，移动端的菜单按钮不显示，但是网页结构已经改变
4. 壁纸展示状态因为 `z-index` 属性的原因，导致 **下载壁纸** 按钮无法点击