### PR TITLE
feat: 优化 logo 区域样式

### DIFF
--- a/src/components/Message.vue
+++ b/src/components/Message.vue
@@ -92,12 +92,13 @@ watch(
     flex-direction: row;
     align-items: center;
     animation: fade 0.5s;
+    max-width: 460px;
     .logo-img {
       border-radius: 50%;
       width: 120px;
     }
     .name {
-      width: calc(460px - 120px);
+      width: 100%;
       padding-left: 22px;
       transform: translateY(-8px);
       font-family: "Pacifico-Regular";
@@ -124,6 +125,10 @@ watch(
           font-size: 4.5rem;
         }
       }
+    }
+
+    @media (max-width: 720px) {
+      max-width: 100%;
     }
   }
 

--- a/src/style/style.scss
+++ b/src/style/style.scss
@@ -38,11 +38,13 @@ p {
 // 字体文件
 @font-face {
   font-family: "Pacifico-Regular";
+  font-display: swap;
   src: url("/font/Pacifico-Regular.ttf") format("truetype");
 }
 
 @font-face {
   font-family: "UnidreamLED";
+  font-display: swap;
   src: url("/font/UnidreamLED.ttf") format("truetype");
 }
 


### PR DESCRIPTION
参考 SocialLinks 样式做的优化，如果按照之前的写法，变成移动端样式的时候，宽度会超过 460px，并且移动端 logo 图标将会隐藏。