### PR TITLE
fix: fix the logo be cut in small screen #157

### DIFF
--- a/src/views/MoreSet/index.vue
+++ b/src/views/MoreSet/index.vue
@@ -136,7 +136,7 @@ const jumpTo = (url) => {
         padding-left: 22px;
         width: 100%;
         height: 260px;
-
+        min-height: 140px;
         .bg {
           font-size: 5rem;
         }


### PR DESCRIPTION
修复了由于`flex-item`自适应高度导致的logo显示不全的问题(#157)