### PR TITLE
🐞 fix: 修复时间胶囊周计算错误

### DIFF
--- a/src/utils/getTime.js
+++ b/src/utils/getTime.js
@@ -45,12 +45,9 @@ export const getTimeCapsule = () => {
     // 计算总的天数或小时数
     const total = end.diff(start, unit === "day" ? "hour" : "day") + 1;
     // 计算已经过去的天数或小时数
-    let passed;
-    if (unit === "week" && now.day() === 0) {
-      // 如果是星期日
-      passed = total - 1;
-    } else {
-      passed = now.diff(start, unit === "day" ? "hour" : "day");
+    let passed = now.diff(start, unit === "day" ? "hour" : "day");
+    if (unit === "week") {
+      passed = (passed + 6) % 7;
     }
     const remaining = total - passed;
     const percentage = (passed / total) * 100;


### PR DESCRIPTION
时间胶囊的周计算错误，原本只是处理了 **星期日** 的情况，但是如果修改为 **星期一** 为第1天的话，那么所有的日期都需要处理，即将 [0, 1, 2, 3, 4, 5, 6] => [6, 0, 1, 2, 3, 4, 5]，即 + 6 然后 % 7 。 